### PR TITLE
Fix string copy test by using predictable struct memory layout for `AllocatedPyASCIIObject`

### DIFF
--- a/src/python_data_access.rs
+++ b/src/python_data_access.rs
@@ -333,6 +333,7 @@ pub mod tests {
     }
 
     #[allow(dead_code)]
+    #[repr(C)] // Rust can optimize the layout of this struct and break our pointer arithmetic
     pub struct AllocatedPyASCIIObject {
         pub base: PyASCIIObject,
         pub storage: [u8; 4096]


### PR DESCRIPTION
Resolves failing test

```
---- python_data_access::tests::test_copy_string stdout ----
copied: "\0\0\0\0\0\0\0\0\0\0\0\0\0"
thread 'python_data_access::tests::test_copy_string' panicked at 'assertion failed: `(left == right)`
  left: `"\0\0\0\0\0\0\0\0\0\0\0\0\0"`,
 right: `"function_name"`', src/python_data_access.rs:490:9
 ```
 
which occurs due to a failure to copy test data during into a `AllocatedPyASCIIObject` during `to_asciiobject` due to optimization of the struct layout by Rust. We can ask for a C-compatible layout to get a consistent layout for pointer arithmetic.