### PR TITLE
Disable armv7 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,19 +20,19 @@ jobs:
       - uses: actions/setup-python@v4
       - uses: pre-commit/action@v3.0.0
 
-  build-linux-armv7:
-    runs-on: [self-hosted, linux, arm]
-    needs: [lint]
-    steps:
-    - name: Setup python
-      run: |
-        pyenv global system
-        python --version
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test
+  # build-linux-armv7:
+  #   runs-on: [self-hosted, linux, arm]
+  #   needs: [lint]
+  #   steps:
+  #   - name: Setup python
+  #     run: |
+  #       pyenv global system
+  #       python --version
+  #   - uses: actions/checkout@v3
+  #   - name: Build
+  #     run: cargo build --verbose
+  #   - name: Run tests
+  #     run: cargo test
 
   build:
     runs-on: ${{ matrix.os }}
@@ -239,38 +239,39 @@ jobs:
         run: sudo "PATH=$PATH" python tests/integration_test.py
         if: steps.osx_test1.outcome=='failure'
 
-  test-wheel-linux-armv7:
-    name: Test ARMv7 Wheel
-    needs: [build-linux-cross]
-    runs-on: [self-hosted, linux, arm]
-    strategy:
-      matrix:
-        # we're installing the manylinux2014 wheel, so can
-        # only test out relatively recent versions of python
-        pyenv-python-version: [3.7.10, 3.8.9, 3.9.4]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
-        with:
-          name: wheels
-      - name: Setup pyenv
-        run: |
-          # build the version of python if not installed already
-          # (note this relies on pyenv being setup already)
-          pyenv install -s ${{ matrix.pyenv-python-version }}
-          pyenv global ${{ matrix.pyenv-python-version }}
-          python --version
-      - name: Install wheel
-        run: |
-          pip install --force-reinstall --no-index --find-links . py-spy
-      - name: Test Wheel
-        run: python tests/integration_test.py
+  # Disabled on fork at madkinsz/py-spy because we do not have self-hosted runners
+  # test-wheel-linux-armv7:
+  #   name: Test ARMv7 Wheel
+  #   needs: [build-linux-cross]
+  #   runs-on: [self-hosted, linux, arm]
+  #   strategy:
+  #     matrix:
+  #       # we're installing the manylinux2014 wheel, so can
+  #       # only test out relatively recent versions of python
+  #       pyenv-python-version: [3.7.10, 3.8.9, 3.9.4]
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: actions/download-artifact@v3
+  #       with:
+  #         name: wheels
+  #     - name: Setup pyenv
+  #       run: |
+  #         # build the version of python if not installed already
+  #         # (note this relies on pyenv being setup already)
+  #         pyenv install -s ${{ matrix.pyenv-python-version }}
+  #         pyenv global ${{ matrix.pyenv-python-version }}
+  #         python --version
+  #     - name: Install wheel
+  #       run: |
+  #         pip install --force-reinstall --no-index --find-links . py-spy
+  #     - name: Test Wheel
+  #       run: python tests/integration_test.py
 
   release:
     name: Release
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [test-wheels, test-wheel-linux-armv7]
+    needs: [test-wheels]
     steps:
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
Replay of #4 on updated upstream

Requires self-hosted runners; todo to build these on standard runners
